### PR TITLE
fixes a bug with declaration picking only first where it should qualify it by type_id

### DIFF
--- a/app/Http/Controllers/DeclarationController.php
+++ b/app/Http/Controllers/DeclarationController.php
@@ -334,8 +334,12 @@ class DeclarationController extends Aeit
             $page2_field_name = 'field_new_dec_req_agreement_text';
         }
 
-        $get_decl = Declaration::where('type', $dectype)->where('program_year', $startYear.'/'.$endYear)->where('status', 1)->with('fields')->first();
+        $get_decl = Declaration::where('type', $dectype)
+            ->where('type_id', 'sabc_'.$dec_vs_consent)
+            ->where('program_year', $startYear.'/'.$endYear)
+            ->where('status', 1)->with('fields')->first();
         if (env('APP_DEBUG') == true && env('APP_ENV') != 'production') {
+            session()->push('DEBUG', now().': loadDec() Dec ID: '.$get_decl->id);
             session()->push('DEBUG', now().': loadDec() dectype: '.$dectype);
             session()->push('DEBUG', now().': loadDec() get_decl: '.is_null($get_decl));
             session()->push('DEBUG', now().': loadDec() startYear: '.$startYear);


### PR DESCRIPTION
This pull request includes updates to the `loadDec` method in the `DeclarationController` to enhance filtering logic and improve debugging capabilities.

### Updates to filtering logic:
* Added a new condition to filter declarations by `type_id` using the format `'sabc_' . $dec_vs_consent`. This ensures more precise filtering of declarations. (`[app/Http/Controllers/DeclarationController.phpL337-R342](diffhunk://#diff-0c297de8602fc03d628a647c4f527854a97664b1999c08e854f56a86a7bf923bL337-R342)`)

### Improvements to debugging:
* Enhanced debug logging by adding a session entry to log the Declaration ID (`$get_decl->id`) when the application is in debug mode and not in production. (`[app/Http/Controllers/DeclarationController.phpL337-R342](diffhunk://#diff-0c297de8602fc03d628a647c4f527854a97664b1999c08e854f56a86a7bf923bL337-R342)`)