### PR TITLE
Upgrade Laravel from V9 to V10:

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
-        \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
@@ -52,7 +52,7 @@ class Kernel extends HttpKernel
      *
      * @var array
      */
-    protected $routeMiddleware = [
+    protected $middlewareAliases = [
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -20,10 +20,6 @@ class AuthServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
-    {
-        $this->registerPolicies();
-
-        //
+    public function boot(): void {
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,20 +13,19 @@
         "ext-fileinfo": "*",
         "ext-json": "*",
         "carlos-meneses/laravel-mpdf": "*",
-        "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
-        "laravel/framework": "^9.0",
+        "laravel/framework": "^10.0",
         "laravel/pint": "^1.3",
         "laravel/tinker": "^2.0",
-        "laravel/ui": "^3.0",
+        "laravel/ui": "^4.0",
         "mpdf/mpdf": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.1",
-        "nunomaduro/collision": "^6.1",
+        "nunomaduro/collision": "^7.0",
         "nunomaduro/larastan": "^2.11",
-        "phpunit/phpunit": "^9.0",
-        "spatie/laravel-ignition": "^1.0"
+        "phpunit/phpunit": "^10.0",
+        "spatie/laravel-ignition": "^2.0"
     },
     "config": {
         "optimize-autoloader": true,
@@ -51,7 +50,7 @@
             "Tests\\": "tests/"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "scripts": {
         "post-autoload-dump": [


### PR DESCRIPTION
### Framework and Dependency Upgrades:
- Updated  laravel/framework to ^10
- Updated laravel/ui to ^4.0
- Updated phpunit/phpunit to ^10.0
- Updated spatie/laravel-ignition to ^2.0
- Updated nunomaduro/collision to 7.0
- Updated composer.son to set to     "minimum-stability": "stable"

### Code adjustments:

- Removed registerPolicies method in /app/Providers/AuthServiceProvider.php: The registerPolicies method of the AuthServiceProvider is now invoked automatically by the framework.
- Replaced \Fruitcake\Cors\HandleCors::class by \Illuminate\Http\Middleware\HandleCors::class in /app/Http/Kernel.php
- In new Laravel applications, the $routeMiddleware property of the App\Http\Kernel class has been renamed to $middlewareAliases to better reflect its purpose.